### PR TITLE
UI overhaul: history, themes, share, auth improvements, search offset fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,11 @@ React + Vite SPA that picks a random Spotify catalog search and starts playback 
 ## Spotify Developer Dashboard
 
 1. Open the [Spotify Developer Dashboard](https://developer.spotify.com/dashboard) and open your app (or create one).
-
 2. Under **Redirect URIs**, add these exactly (character-for-character):
-   - `http://localhost:8888/callback` — local dev (`npm run dev`; Vite uses port **8888**)
-   - `https://saarhaber.github.io/randomSong/callback` — production (GitHub Pages)
-
+  - `http://localhost:8888/callback` — local dev (`npm run dev`; Vite uses port **8888**)
+  - `https://saarhaber.github.io/randomSong/callback` — production (GitHub Pages)
 3. The **Client ID** is embedded; public OAuth clients are not secret. **Do not** put the **Client Secret** in frontend code — PKCE does not use it. If you fork, set `VITE_SPOTIFY_CLIENT_ID` in `.env` or in GitHub Actions for your own app.
-
-4. If login fails with **`redirect_uri` not matching**, the URIs in step 2 are missing or incorrect. Spotify compares the full string (scheme, host, path; no trailing slash after `callback`).
+4. If login fails with `**redirect_uri` not matching**, the URIs in step 2 are missing or incorrect. Spotify compares the full string (scheme, host, path; no trailing slash after `callback`).
 
 ## Local development
 
@@ -23,18 +20,16 @@ npm install
 npm run dev
 ```
 
-Serves at **http://localhost:8888**. Register `http://localhost:8888/callback` on your Spotify app (step 2).
+Serves at **[http://localhost:8888](http://localhost:8888)**. Register `http://localhost:8888/callback` on your Spotify app (step 2).
 
 ## Deploy (GitHub Pages)
 
-1. **Settings → Pages → Build and deployment → Source:** choose **GitHub Actions** and save.  
-   Leaving **Deploy from a branch** selected causes the deploy job to fail with **HTTP 404** when creating a Pages deployment (`actions/deploy-pages` cannot provision the site).
-
+1. **Settings → Pages → Build and deployment → Source:** choose **GitHub Actions** and save.
+  Leaving **Deploy from a branch** selected causes the deploy job to fail with **HTTP 404** when creating a Pages deployment (`actions/deploy-pages` cannot provision the site).
 2. *(Optional)* **Settings → Secrets and variables → Actions:** set `VITE_SPOTIFY_CLIENT_ID` if the CI build should override the default client ID (e.g. a fork).
-
 3. Push to `master` or run the workflow manually. The build uploads `dist/`; the deploy job publishes it.
 
-The workflow grants **`pages: write`** and **`id-token: write`** only to the **deploy** job, as required by [`actions/deploy-pages`](https://github.com/actions/deploy-pages#usage).
+The workflow grants `**pages: write`** and `**id-token: write**` only to the **deploy** job, as required by `[actions/deploy-pages](https://github.com/actions/deploy-pages#usage)`.
 
 ## Requirements
 

--- a/index.html
+++ b/index.html
@@ -3,7 +3,29 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Play a completely random song from Spotify. Log in, hit play, discover something new."
+    />
+    <meta name="theme-color" content="#0c0c0e" />
     <title>Random Song</title>
+    <link rel="icon" type="image/svg+xml" href="favicon.svg" />
+    <link rel="manifest" href="manifest.webmanifest" />
+    <script>
+      (function () {
+        try {
+          var k = "rs-theme";
+          var stored = localStorage.getItem(k);
+          var theme =
+            stored === "light" || stored === "dark"
+              ? stored
+              : window.matchMedia("(prefers-color-scheme: light)").matches
+                ? "light"
+                : "dark";
+          document.documentElement.setAttribute("data-theme", theme);
+        } catch (e) {}
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <defs>
+    <linearGradient id="g" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#1ed760" />
+      <stop offset="100%" stop-color="#169c46" />
+    </linearGradient>
+  </defs>
+  <rect x="1" y="1" width="30" height="30" rx="8" fill="url(#g)" />
+  <text x="16" y="22" text-anchor="middle" font-size="15" fill="#0d0d0d" font-family="system-ui,sans-serif" font-weight="700">j</text>
+</svg>

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,0 +1,17 @@
+{
+  "name": "Random Song",
+  "short_name": "Random Song",
+  "description": "Play a completely random song from Spotify.",
+  "start_url": "./",
+  "display": "standalone",
+  "background_color": "#0c0c0e",
+  "theme_color": "#0c0c0e",
+  "icons": [
+    {
+      "src": "favicon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any maskable"
+    }
+  ]
+}

--- a/src/App.css
+++ b/src/App.css
@@ -1,15 +1,237 @@
-.app {
-  max-width: 28rem;
-  margin: 0 auto;
-  padding: 2rem 1.25rem;
+.shell {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.shell--center {
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
   text-align: center;
 }
 
-.app h1 {
+.top-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 1.25rem;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-elevated);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.brand--hero {
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.brand__name {
+  font-size: 1.15rem;
+  font-weight: 700;
+  letter-spacing: -0.03em;
+  margin: 0;
+}
+
+.logo-lg {
+  width: 48px;
+  height: 48px;
+}
+
+.icon-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  padding: 0;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--surface);
+  color: var(--text);
+  cursor: pointer;
+  transition:
+    background 0.15s ease,
+    border-color 0.15s ease;
+}
+
+.icon-btn:hover {
+  background: var(--bg-elevated);
+  border-color: var(--text-muted);
+}
+
+.theme-toggle__icon {
+  font-size: 1.1rem;
+  line-height: 1;
+}
+
+.toast {
+  position: fixed;
+  bottom: 1.25rem;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 20;
+  padding: 0.6rem 1rem;
+  border-radius: 999px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow);
+  font-size: 0.9rem;
+}
+
+.layout {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0;
+  flex: 1;
+  width: 100%;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 1rem 1rem 2rem;
+}
+
+@media (min-width: 900px) {
+  .layout {
+    grid-template-columns: minmax(0, 1fr) minmax(280px, 340px);
+    gap: 1.5rem;
+    align-items: start;
+  }
+}
+
+.main {
+  min-width: 0;
+}
+
+.sidebar {
+  min-width: 0;
+}
+
+.shared-banner {
+  margin-bottom: 1rem;
+  padding: 1rem;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background: var(--surface);
+}
+
+.shared-banner__inner {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem 1rem;
+}
+
+.shared-banner__inner--compact {
+  gap: 0.5rem;
+}
+
+.shared-banner__cover {
+  width: 56px;
+  height: 56px;
+  border-radius: 8px;
+  object-fit: cover;
+}
+
+.shared-banner__label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+}
+
+.shared-banner__title {
+  font-weight: 600;
+  font-size: 1rem;
+}
+
+.shared-banner__artist {
+  font-size: 0.9rem;
+  color: var(--text-muted);
+}
+
+.app-title {
   font-size: 1.5rem;
   font-weight: 600;
   margin: 0 0 1.5rem;
   letter-spacing: -0.02em;
+}
+
+.card {
+  padding: 1.25rem;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  margin-bottom: 1rem;
+}
+
+.card--auth {
+  text-align: center;
+}
+
+.login-lead {
+  margin: 0 0 1rem;
+  font-size: 0.95rem;
+  line-height: 1.5;
+  color: var(--text-muted);
+}
+
+.btn-lg {
+  padding: 0.75rem 1.5rem;
+  font-size: 1.05rem;
+}
+
+.hint--tight {
+  margin-top: 1rem;
+  max-width: 26rem;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.login-warmup {
+  margin: 1.25rem 0 0;
+  padding: 0.85rem 1rem;
+  border-radius: 10px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  font-size: 0.88rem;
+  line-height: 1.45;
+  color: var(--text-muted);
+  text-align: left;
+}
+
+.login-warmup__label {
+  display: block;
+  font-weight: 600;
+  color: var(--text);
+  margin-bottom: 0.25rem;
+}
+
+.login-warmup__link {
+  font-weight: 600;
+}
+
+.user-row {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin-bottom: 1rem;
+}
+
+.actions-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  justify-content: center;
 }
 
 .btn {
@@ -23,9 +245,13 @@
   border: none;
   border-radius: 999px;
   cursor: pointer;
-  background: #1db954;
+  background: var(--accent);
   color: #121212;
   transition: filter 0.15s ease;
+}
+
+[data-theme="light"] .btn {
+  color: #fafafa;
 }
 
 .btn:hover {
@@ -38,46 +264,125 @@
 }
 
 .btn-secondary {
-  background: #333;
-  color: #fafafa;
+  background: var(--bg-elevated);
+  color: var(--text);
+  border: 1px solid var(--border);
+}
+
+.btn-secondary:hover {
+  filter: none;
+  border-color: var(--text-muted);
+}
+
+.btn-sm {
+  padding: 0.45rem 0.9rem;
+  font-size: 0.9rem;
+}
+
+.btn-text {
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  color: var(--accent);
+  cursor: pointer;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.btn-text:hover {
+  color: var(--accent-hover);
 }
 
 .meta {
-  margin-top: 1rem;
   font-size: 0.9rem;
-  color: #b3b3b3;
+  color: var(--text-muted);
+}
+
+.kbd-hint {
+  margin-top: 1rem;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  text-align: center;
 }
 
 .now-playing {
-  margin-top: 1.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
 }
 
-.now-playing .title {
-  font-size: 1.1rem;
+@media (min-width: 520px) {
+  .now-playing.card--now {
+    flex-direction: row;
+    align-items: flex-start;
+    justify-content: space-between;
+    text-align: left;
+  }
+}
+
+.now-playing__text {
+  flex: 1;
+  min-width: 0;
+}
+
+.now-playing__title {
+  font-size: 1.2rem;
   font-weight: 600;
   line-height: 1.35;
   margin-bottom: 0.35rem;
 }
 
-.now-playing .artist {
+.now-playing__artist {
   font-size: 0.95rem;
-  color: #b3b3b3;
+  color: var(--text-muted);
+}
+
+.now-playing__album {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  margin-top: 0.25rem;
+}
+
+.now-playing__links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem 1rem;
+  margin-top: 0.75rem;
+  align-items: center;
+}
+
+.link-inline {
+  color: var(--accent);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.link-inline:hover {
+  text-decoration: underline;
 }
 
 .cover {
-  margin-top: 1.25rem;
   width: min(100%, 280px);
+  max-width: 280px;
   height: auto;
-  border-radius: 8px;
-  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.45);
+  border-radius: 10px;
+  box-shadow: var(--shadow);
+  align-self: center;
+}
+
+@media (min-width: 520px) {
+  .cover {
+    align-self: flex-start;
+  }
 }
 
 .error {
-  margin-top: 1rem;
+  margin-bottom: 1rem;
   padding: 0.75rem 1rem;
   border-radius: 8px;
-  background: #3d1a1a;
-  color: #ffb4b4;
+  background: var(--danger-bg);
+  color: var(--danger-text);
   font-size: 0.9rem;
   text-align: left;
 }
@@ -92,6 +397,108 @@
 .hint {
   margin-top: 1.25rem;
   font-size: 0.85rem;
-  color: #777;
+  color: var(--text-muted);
   line-height: 1.45;
+}
+
+/* History sidebar */
+.history-panel {
+  position: sticky;
+  top: 4rem;
+  padding: 1rem;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  max-height: min(70vh, 640px);
+  display: flex;
+  flex-direction: column;
+}
+
+.history-panel__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.history-panel__title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.history-panel__empty {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--text-muted);
+}
+
+.history-table-wrap {
+  overflow: auto;
+  flex: 1;
+  margin: 0 -0.25rem;
+}
+
+.history-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.85rem;
+}
+
+.history-table th {
+  text-align: left;
+  padding: 0.35rem 0.5rem;
+  color: var(--text-muted);
+  font-weight: 500;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.history-table td {
+  padding: 0.5rem;
+  vertical-align: top;
+  border-top: 1px solid var(--border);
+}
+
+.history-table__thumb-col {
+  width: 48px;
+}
+
+.history-table__thumb {
+  width: 40px;
+  height: 40px;
+  border-radius: 6px;
+  object-fit: cover;
+  display: block;
+}
+
+.history-table__link {
+  color: var(--text);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.history-table__link:hover {
+  color: var(--accent);
+}
+
+.history-table__meta {
+  color: var(--text-muted);
+  font-size: 0.8rem;
+  margin-top: 0.15rem;
+}
+
+.history-table__when {
+  color: var(--text-muted);
+  white-space: nowrap;
+  font-size: 0.8rem;
+}
+
+@media (max-width: 899px) {
+  .history-panel {
+    position: static;
+    max-height: none;
+  }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,17 +1,33 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import Spotify from "spotify-web-api-js";
 import "./App.css";
+import { HistoryPanel } from "./components/HistoryPanel";
+import { Logo } from "./components/Logo";
+import { ThemeToggle } from "./components/ThemeToggle";
+import { addToBlacklist, getBlacklist } from "./blacklistStore";
+import { appendHistory, clearHistory, getHistory } from "./historyStore";
 import {
   beginLogin,
   clearStoredTokens,
   ensureValidAccessToken,
   exchangeCodeForTokens,
   getClientId,
+  isAndroidMobile,
+  isIosMobile,
   parseOAuthCallback,
+  SPOTIFY_ACCOUNTS_LOGIN_URL,
   validateOAuthState,
 } from "./spotifyPkce";
 import { formatSpotifyApiError } from "./spotifyErrors";
+import { applyTheme, type ThemeMode, toggleTheme } from "./theme";
+import {
+  appBaseUrl,
+  emptyNowPlaying,
+  trackToNowPlaying,
+  type HistoryEntry,
+  type NowPlaying,
+} from "./trackUtils";
 
 const spotify = new Spotify();
 
@@ -83,9 +99,6 @@ const MARKETS = [
   "ZA",
 ] as const;
 
-const DEFAULT_IMG =
-  "https://images.squarespace-cdn.com/content/v1/585e12abe4fcb5ea1248900e/1521163355433-O0YP7FRVMXHTCHB1O4CU/ke17ZwdGBToddI8pDm48kPx25wW2-RVvoRgxIT6HShBZw-zPPgdn4jUwVcJE1ZvWQUxwkmyExglNqGp0IvTJZUJFbgE-7XRK3dMEBRBhUpx0Qh3eD5PfZ_nDR0M7OIGaTx-0Okj4hzQeRKYKbt7WfTYFScRKDTW78PcnUqBGqX8/Spotify+Square.png";
-
 function getRandomSearch(): string {
   const characters =
     "ﺍﺏﺕﺙﺝﺡﺥﺩﺫﺭﺯﺱﺵﺹﺽﻁﻅﻉﻍﻑﻕﻙﻝﻡﻥهـﻭﻱБВГДЖꙂꙀИЛѠЦЧШЩЪѢꙖѤЮѪѬѦѨѮѰѲѴҀňřšťůýÿžäëðöüăïîāņßķõőàèòùčēļșģìאבגדהוזחטיכלמנסעפצקרשתľơŕçởżğæœøåabcdefghijklmnñopqrstuvwxyz0123456789áéíóúαβγδεζηθικλμνξΟοΠπρςτυφχψωč";
@@ -102,21 +115,50 @@ function getRandomSearch(): string {
   }
 }
 
+function initialTheme(): ThemeMode {
+  if (typeof window === "undefined") return "dark";
+  try {
+    const v = localStorage.getItem("rs-theme");
+    if (v === "light" || v === "dark") return v;
+  } catch {
+    /* ignore */
+  }
+  return window.matchMedia("(prefers-color-scheme: light)").matches ? "light" : "dark";
+}
+
 export default function App() {
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const sharedTrackId = searchParams.get("track");
+
   const [ready, setReady] = useState(false);
   const [oauthBusy, setOauthBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [loggedIn, setLoggedIn] = useState(false);
   const [displayName, setDisplayName] = useState("");
   const [userImg, setUserImg] = useState("");
-  const [nowPlaying, setNowPlaying] = useState({
-    name: "",
-    image: DEFAULT_IMG,
-    artist: "",
-  });
+  const [nowPlaying, setNowPlaying] = useState<NowPlaying>(() => emptyNowPlaying());
   const [playing, setPlaying] = useState(false);
+  const [theme, setTheme] = useState<ThemeMode>(initialTheme);
+  const [historyEntries, setHistoryEntries] = useState<HistoryEntry[]>(() => getHistory());
+  const [sharedPreview, setSharedPreview] = useState<NowPlaying | null>(null);
+  const [toast, setToast] = useState<string | null>(null);
   const playInFlight = useRef(false);
+  const shareInFlight = useRef(false);
+  const playNowRef = useRef<() => Promise<void>>(async () => {});
+  /** Last polled playback snapshot for the same track (detect end-of-track). */
+  const playbackSnapRef = useRef<{
+    trackId: string;
+    isPlaying: boolean;
+    progress: number;
+    duration: number;
+  } | null>(null);
+  /** Avoid double-firing auto-chain for the same track id. */
+  const autoChainedFromTrackRef = useRef<string | null>(null);
+
+  const refreshHistory = useCallback(() => {
+    setHistoryEntries(getHistory());
+  }, []);
 
   const applyToken = useCallback(async (token: string) => {
     spotify.setAccessToken(token);
@@ -129,23 +171,57 @@ export default function App() {
     const playback = await spotify.getMyCurrentPlaybackState();
     if (playback?.is_playing && playback.item && "name" in playback.item) {
       const t = playback.item;
-      setNowPlaying({
-        name: t.name,
-        image: t.album.images[0]?.url ?? DEFAULT_IMG,
-        artist: t.artists[0]?.name ?? "",
-      });
+      setNowPlaying(trackToNowPlaying(t));
     } else {
       const recent = await spotify.getMyRecentlyPlayedTracks({ limit: 1 });
       const first = recent.items[0]?.track;
       if (first) {
-        setNowPlaying({
-          name: first.name,
-          image: first.album.images[0]?.url ?? DEFAULT_IMG,
-          artist: first.artists[0]?.name ?? "",
-        });
+        setNowPlaying(trackToNowPlaying(first));
       }
     }
   }, []);
+
+  useEffect(() => {
+    applyTheme(theme);
+  }, [theme]);
+
+  useEffect(() => {
+    if (!toast) return;
+    const t = window.setTimeout(() => setToast(null), 2200);
+    return () => window.clearTimeout(t);
+  }, [toast]);
+
+  useEffect(() => {
+    if (!sharedTrackId) {
+      setSharedPreview(null);
+      return;
+    }
+    let cancelled = false;
+
+    async function loadShared() {
+      const id = sharedTrackId;
+      if (!id) return;
+      const token = await ensureValidAccessToken();
+      if (!token) {
+        setSharedPreview(null);
+        return;
+      }
+      try {
+        spotify.setAccessToken(token);
+        const t = await spotify.getTrack(id);
+        if (!cancelled && t) {
+          setSharedPreview(trackToNowPlaying(t));
+        }
+      } catch {
+        if (!cancelled) setSharedPreview(null);
+      }
+    }
+
+    void loadShared();
+    return () => {
+      cancelled = true;
+    };
+  }, [sharedTrackId, loggedIn]);
 
   useEffect(() => {
     let cancelled = false;
@@ -205,6 +281,7 @@ export default function App() {
           setLoggedIn(false);
         }
       }
+      refreshHistory();
       setOauthBusy(false);
       setReady(true);
     }
@@ -213,19 +290,46 @@ export default function App() {
     return () => {
       cancelled = true;
     };
-  }, [applyToken, navigate]);
+  }, [applyToken, navigate, refreshHistory]);
 
   const getNowPlaying = useCallback(async () => {
     const playback = await spotify.getMyCurrentPlaybackState();
     if (playback?.is_playing && playback.item && "name" in playback.item) {
       const t = playback.item;
-      setNowPlaying({
-        name: t.name,
-        image: t.album.images[0]?.url ?? DEFAULT_IMG,
-        artist: t.artists[0]?.name ?? "",
-      });
+      setNowPlaying(trackToNowPlaying(t));
     }
   }, []);
+
+  const handleShare = useCallback(async () => {
+    if (!nowPlaying.id || shareInFlight.current) return;
+    shareInFlight.current = true;
+    const base = appBaseUrl().replace(/\/$/, "");
+    const appWithTrack = `${base}/?track=${encodeURIComponent(nowPlaying.id)}`;
+    const text = `I found "${nowPlaying.name}" by ${nowPlaying.artist} on Random Song — ${appWithTrack}\n${nowPlaying.externalUrl}`;
+    try {
+      if (navigator.share) {
+        await navigator.share({
+          title: "Random Song",
+          text,
+          url: appWithTrack,
+        });
+      } else {
+        await navigator.clipboard.writeText(text);
+        setToast("Copied to clipboard");
+      }
+    } catch (e) {
+      if ((e as Error).name !== "AbortError") {
+        try {
+          await navigator.clipboard.writeText(text);
+          setToast("Copied to clipboard");
+        } catch {
+          setToast("Could not share — copy the link manually");
+        }
+      }
+    } finally {
+      shareInFlight.current = false;
+    }
+  }, [nowPlaying]);
 
   const playNow = useCallback(async () => {
     if (playInFlight.current) {
@@ -253,10 +357,13 @@ export default function App() {
 
       const market = MARKETS[Math.floor(Math.random() * MARKETS.length)]!;
       const search = getRandomSearch();
-      const offset = Math.floor(Math.random() * 2000);
+      /** Spotify search: limit + offset must not exceed 1000. */
+      const searchLimit = 50;
+      const maxOffset = 1000 - searchLimit;
+      const offset = Math.floor(Math.random() * (maxOffset + 1));
       const response = await spotify.search(search, ["track"], {
         market,
-        limit: 50,
+        limit: searchLimit,
         offset,
       });
       const items = response.tracks?.items ?? [];
@@ -264,8 +371,17 @@ export default function App() {
         setError("No tracks returned — try again.");
         return;
       }
-      const pick = items[Math.floor(Math.random() * items.length)]!;
+      const blacklist = getBlacklist();
+      let pool = items.filter((t) => !blacklist.has(t.id));
+      if (pool.length === 0) {
+        pool = items;
+      }
+      const pick = pool[Math.floor(Math.random() * pool.length)]!;
       await spotify.play({ uris: [pick.uri] });
+      const played = trackToNowPlaying(pick);
+      setNowPlaying(played);
+      appendHistory(played);
+      refreshHistory();
       await new Promise((r) => setTimeout(r, 800));
       await getNowPlaying();
     } catch (e) {
@@ -274,7 +390,104 @@ export default function App() {
       playInFlight.current = false;
       setPlaying(false);
     }
-  }, [getNowPlaying]);
+  }, [getNowPlaying, refreshHistory]);
+
+  playNowRef.current = playNow;
+
+  /** When the active Spotify track ends (near end, then stops), queue another random song. */
+  useEffect(() => {
+    if (!loggedIn || !ready) {
+      playbackSnapRef.current = null;
+      autoChainedFromTrackRef.current = null;
+      return;
+    }
+
+    const NEAR_END_MS = 4000;
+    const STUCK_NEAR_END_MS = 3000;
+    const POLL_MS = 2000;
+
+    const tick = async () => {
+      if (playInFlight.current) return;
+      try {
+        const token = await ensureValidAccessToken();
+        if (!token) return;
+        spotify.setAccessToken(token);
+        const playback = await spotify.getMyCurrentPlaybackState();
+        const raw = playback?.item;
+        if (!raw || !("album" in raw)) {
+          playbackSnapRef.current = null;
+          return;
+        }
+        const track = raw as { id: string; duration_ms: number };
+        const duration = track.duration_ms ?? 0;
+        const progress = playback.progress_ms ?? 0;
+        const isPlaying = playback.is_playing ?? false;
+        const trackId = track.id;
+
+        const prev = playbackSnapRef.current;
+        const next = { trackId, isPlaying, progress, duration };
+
+        const transitionEnded =
+          prev &&
+          prev.trackId === trackId &&
+          prev.isPlaying &&
+          !isPlaying &&
+          duration > 0 &&
+          prev.progress >= duration - NEAR_END_MS;
+
+        const stuckEnded =
+          prev &&
+          prev.trackId === trackId &&
+          !isPlaying &&
+          duration > 0 &&
+          progress >= duration - STUCK_NEAR_END_MS;
+
+        if (
+          (transitionEnded || stuckEnded) &&
+          autoChainedFromTrackRef.current !== trackId
+        ) {
+          autoChainedFromTrackRef.current = trackId;
+          void playNowRef.current();
+        }
+
+        playbackSnapRef.current = next;
+      } catch {
+        /* ignore network / rate limits */
+      }
+    };
+
+    const id = window.setInterval(() => void tick(), POLL_MS);
+    return () => {
+      window.clearInterval(id);
+    };
+  }, [loggedIn, ready]);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement | null;
+      if (
+        target &&
+        (target.tagName === "INPUT" ||
+          target.tagName === "TEXTAREA" ||
+          target.isContentEditable)
+      ) {
+        return;
+      }
+      if (e.code === "Space") {
+        e.preventDefault();
+        if (loggedIn && !playing) {
+          void playNow();
+        }
+      }
+      if (e.key === "s" || e.key === "S") {
+        if (nowPlaying.id) {
+          void handleShare();
+        }
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [loggedIn, playing, playNow, nowPlaying.id, handleShare]);
 
   const onLogin = () => {
     setError(null);
@@ -288,70 +501,229 @@ export default function App() {
     setLoggedIn(false);
     setDisplayName("");
     setUserImg("");
-    setNowPlaying({ name: "", image: DEFAULT_IMG, artist: "" });
+    setNowPlaying(emptyNowPlaying());
     setError(null);
+    setSharedPreview(null);
+    playbackSnapRef.current = null;
+    autoChainedFromTrackRef.current = null;
+  };
+
+  const onClearHistory = () => {
+    clearHistory();
+    refreshHistory();
+  };
+
+  const onThemeToggle = () => {
+    setTheme((prev) => toggleTheme(prev));
+  };
+
+  const onBlacklistCurrent = () => {
+    if (!nowPlaying.id) return;
+    addToBlacklist(nowPlaying.id);
+    setToast("Track won’t be picked again (unless no alternatives)");
   };
 
   if (!ready || oauthBusy) {
     return (
-      <div className="app">
-        <h1>Random Song</h1>
+      <div className="shell shell--center">
+        <div className="brand brand--hero">
+          <Logo className="logo-lg" />
+          <h1 className="app-title">Random Song</h1>
+        </div>
         <p className="meta">Loading…</p>
       </div>
     );
   }
 
+  const sharedOpenUrl = sharedTrackId
+    ? `https://open.spotify.com/track/${sharedTrackId}`
+    : "";
+
   return (
-    <div className="app">
-      <h1>Random Song</h1>
+    <div className="shell">
+      <header className="top-bar">
+        <div className="brand">
+          <Logo />
+          <h1 className="brand__name">Random Song</h1>
+        </div>
+        <ThemeToggle theme={theme} onToggle={onThemeToggle} />
+      </header>
 
-      {error ? <div className="error">{error}</div> : null}
+      {toast ? (
+        <div className="toast" role="status">
+          {toast}
+        </div>
+      ) : null}
 
-      {!loggedIn ? (
-        <>
-          <button type="button" className="btn" onClick={onLogin}>
-            Log in with Spotify
-          </button>
-          <p className="hint">
-            Spotify Premium is required for playback control. Open the Spotify app on a device
-            first if playback does not start.
-          </p>
-        </>
-      ) : (
-        <>
-          <div className="meta">
-            Logged in as <strong>{displayName}</strong>
-            {userImg ? (
-              <img className="avatar" src={userImg} alt="" />
-            ) : null}
-          </div>
-          <div style={{ marginTop: "1rem", display: "flex", gap: "0.5rem", justifyContent: "center", flexWrap: "wrap" }}>
-            <button
-              type="button"
-              className="btn"
-              onClick={() => void playNow()}
-              disabled={playing}
-            >
-              {playing ? "Playing…" : "Play random song"}
-            </button>
-            <button type="button" className="btn btn-secondary" onClick={onLogout}>
-              Log out
-            </button>
-          </div>
+      <div className="layout">
+        <main className="main">
+          {sharedTrackId ? (
+            <section className="shared-banner" aria-label="Shared track">
+              {sharedPreview ? (
+                <div className="shared-banner__inner">
+                  <img
+                    className="shared-banner__cover"
+                    src={sharedPreview.image}
+                    alt=""
+                    width={56}
+                    height={56}
+                  />
+                  <div>
+                    <div className="shared-banner__label">Shared track</div>
+                    <div className="shared-banner__title">{sharedPreview.name}</div>
+                    <div className="shared-banner__artist">{sharedPreview.artist}</div>
+                  </div>
+                  <a
+                    className="btn btn-secondary btn-sm"
+                    href={sharedPreview.externalUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Open in Spotify
+                  </a>
+                </div>
+              ) : (
+                <div className="shared-banner__inner shared-banner__inner--compact">
+                  <span className="shared-banner__label">Shared track</span>
+                  <a
+                    className="link-inline"
+                    href={sharedOpenUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Open in Spotify
+                  </a>
+                  {loggedIn ? <span className="meta">Loading details…</span> : null}
+                </div>
+              )}
+            </section>
+          ) : null}
 
-          {(nowPlaying.name || nowPlaying.artist) && (
-            <div className="now-playing">
-              <div className="title">{nowPlaying.name}</div>
-              <div className="artist">{nowPlaying.artist}</div>
-              <img
-                className="cover"
-                src={nowPlaying.image}
-                alt=""
-              />
+          {error ? (
+            <div className="error" role="alert">
+              {error}
             </div>
+          ) : null}
+
+          {!loggedIn ? (
+            <div className="card card--auth">
+              <p className="login-lead">
+                Connect once so Random Song can control playback on your Spotify devices.{" "}
+                <strong>Premium</strong> is required.
+              </p>
+              <button type="button" className="btn btn-lg" onClick={onLogin}>
+                Connect Spotify
+              </button>
+              {isAndroidMobile() ? (
+                <p className="hint hint--tight">
+                  On Android, this opens the <strong>Spotify app</strong> if it’s installed (you stay
+                  logged in there). Otherwise your browser completes sign-in.
+                </p>
+              ) : isIosMobile() ? (
+                <p className="hint hint--tight">
+                  On iPhone, sign-in happens in Safari. If you only use Spotify in the app, use the{" "}
+                  <strong>same email</strong> or tap <strong>Continue with Apple / Google</strong> on
+                  Spotify’s page — that matches many app accounts.
+                </p>
+              ) : (
+                <p className="hint hint--tight">
+                  Use the same Spotify account you use in the app. If the browser asks for a password
+                  but the app logs you in automatically, you may need to set a Spotify password or use
+                  Google/Apple on the web.
+                </p>
+              )}
+              <p className="login-warmup">
+                <span className="login-warmup__label">Having trouble?</span>{" "}
+                <a
+                  href={SPOTIFY_ACCOUNTS_LOGIN_URL}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="login-warmup__link"
+                >
+                  Log in to Spotify in the browser first
+                </a>{" "}
+                (cookies are shared with Connect in this browser), then tap{" "}
+                <strong>Connect Spotify</strong> again.
+              </p>
+              <p className="hint">
+                Open the Spotify app on a phone or desktop first if playback does not start after you
+                connect.
+              </p>
+            </div>
+          ) : (
+            <>
+              <div className="card">
+                <div className="user-row">
+                  <span className="meta">
+                    Logged in as <strong>{displayName}</strong>
+                  </span>
+                  {userImg ? <img className="avatar" src={userImg} alt="" /> : null}
+                </div>
+                <div className="actions-row">
+                  <button
+                    type="button"
+                    className="btn"
+                    onClick={() => void playNow()}
+                    disabled={playing}
+                  >
+                    {playing ? "Playing…" : "Play random song"}
+                  </button>
+                  <button
+                    type="button"
+                    className="btn btn-secondary"
+                    onClick={() => void handleShare()}
+                    disabled={!nowPlaying.id}
+                    title="Share (S)"
+                  >
+                    Share
+                  </button>
+                  <button type="button" className="btn btn-secondary" onClick={onLogout}>
+                    Log out
+                  </button>
+                </div>
+                <p className="kbd-hint">
+                  <kbd>Space</kbd> random play · <kbd>S</kbd> share · When a track ends, another random
+                  song starts automatically.
+                </p>
+              </div>
+
+              {(nowPlaying.name || nowPlaying.artist) && (
+                <div className="now-playing card card--now">
+                  <div className="now-playing__text">
+                    <div className="now-playing__title">{nowPlaying.name}</div>
+                    <div className="now-playing__artist">{nowPlaying.artist}</div>
+                    {nowPlaying.album ? (
+                      <div className="now-playing__album">{nowPlaying.album}</div>
+                    ) : null}
+                    <div className="now-playing__links">
+                      {nowPlaying.externalUrl ? (
+                        <a
+                          className="link-inline"
+                          href={nowPlaying.externalUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                        >
+                          Open in Spotify
+                        </a>
+                      ) : null}
+                      {nowPlaying.id ? (
+                        <button type="button" className="btn-text" onClick={onBlacklistCurrent}>
+                          Don’t suggest again
+                        </button>
+                      ) : null}
+                    </div>
+                  </div>
+                  <img className="cover" src={nowPlaying.image} alt="" />
+                </div>
+              )}
+            </>
           )}
-        </>
-      )}
+        </main>
+
+        <aside className="sidebar">
+          <HistoryPanel entries={historyEntries} onClear={onClearHistory} />
+        </aside>
+      </div>
     </div>
   );
 }

--- a/src/blacklistStore.ts
+++ b/src/blacklistStore.ts
@@ -1,0 +1,37 @@
+const KEY = "rs-blacklist-v1";
+
+function loadIds(): string[] {
+  try {
+    const raw = localStorage.getItem(KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((x): x is string => typeof x === "string" && x.length > 0);
+  } catch {
+    return [];
+  }
+}
+
+function save(ids: string[]) {
+  try {
+    localStorage.setItem(KEY, JSON.stringify(ids));
+  } catch {
+    /* ignore */
+  }
+}
+
+export function getBlacklist(): Set<string> {
+  return new Set(loadIds());
+}
+
+export function addToBlacklist(trackId: string): void {
+  if (!trackId) return;
+  const ids = loadIds();
+  if (ids.includes(trackId)) return;
+  save([trackId, ...ids].slice(0, 500));
+}
+
+export function removeFromBlacklist(trackId: string): void {
+  const ids = loadIds().filter((id) => id !== trackId);
+  save(ids);
+}

--- a/src/components/HistoryPanel.tsx
+++ b/src/components/HistoryPanel.tsx
@@ -1,0 +1,73 @@
+import type { HistoryEntry } from "../trackUtils";
+
+type HistoryPanelProps = {
+  entries: HistoryEntry[];
+  onClear: () => void;
+};
+
+function formatWhen(iso: string): string {
+  try {
+    const d = new Date(iso);
+    return d.toLocaleString(undefined, {
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  } catch {
+    return "";
+  }
+}
+
+export function HistoryPanel({ entries, onClear }: HistoryPanelProps) {
+  return (
+    <section className="history-panel" aria-labelledby="history-heading">
+      <div className="history-panel__head">
+        <h2 id="history-heading" className="history-panel__title">
+          History
+        </h2>
+        {entries.length > 0 ? (
+          <button type="button" className="btn-text" onClick={onClear}>
+            Clear
+          </button>
+        ) : null}
+      </div>
+      {entries.length === 0 ? (
+        <p className="history-panel__empty">Songs you play appear here.</p>
+      ) : (
+        <div className="history-table-wrap">
+          <table className="history-table">
+            <thead>
+              <tr>
+                <th scope="col" className="history-table__thumb-col">
+                  <span className="sr-only">Art</span>
+                </th>
+                <th scope="col">Track</th>
+                <th scope="col">When</th>
+              </tr>
+            </thead>
+            <tbody>
+              {entries.map((row) => (
+                <tr key={`${row.id}-${row.playedAt}`}>
+                  <td>
+                    <img className="history-table__thumb" src={row.image} alt="" width={40} height={40} />
+                  </td>
+                  <td className="history-table__track">
+                    <a href={row.externalUrl} target="_blank" rel="noopener noreferrer" className="history-table__link">
+                      {row.name}
+                    </a>
+                    <div className="history-table__meta">
+                      {row.artist}
+                      {row.album ? ` · ${row.album}` : ""}
+                    </div>
+                  </td>
+                  <td className="history-table__when">{formatWhen(row.playedAt)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/Logo.tsx
+++ b/src/components/Logo.tsx
@@ -1,0 +1,32 @@
+type LogoProps = { className?: string };
+
+export function Logo({ className }: LogoProps) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 32 32"
+      width="32"
+      height="32"
+      aria-hidden
+    >
+      <defs>
+        <linearGradient id="logoGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+          <stop offset="0%" stopColor="var(--logo-grad-a, #1ed760)" />
+          <stop offset="100%" stopColor="var(--logo-grad-b, #169c46)" />
+        </linearGradient>
+      </defs>
+      <rect x="1" y="1" width="30" height="30" rx="8" fill="url(#logoGrad)" />
+      <text
+        x="16"
+        y="22"
+        textAnchor="middle"
+        fontSize="15"
+        fill="var(--logo-fg, #0d0d0d)"
+        fontFamily="system-ui, sans-serif"
+        fontWeight="700"
+      >
+        ♪
+      </text>
+    </svg>
+  );
+}

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,23 @@
+import type { ThemeMode } from "../theme";
+
+type ThemeToggleProps = {
+  theme: ThemeMode;
+  onToggle: () => void;
+};
+
+export function ThemeToggle({ theme, onToggle }: ThemeToggleProps) {
+  const label = theme === "dark" ? "Switch to light mode" : "Switch to dark mode";
+  return (
+    <button type="button" className="icon-btn theme-toggle" onClick={onToggle} aria-label={label} title={label}>
+      {theme === "dark" ? (
+        <span className="theme-toggle__icon" aria-hidden>
+          ☀
+        </span>
+      ) : (
+        <span className="theme-toggle__icon" aria-hidden>
+          ☽
+        </span>
+      )}
+    </button>
+  );
+}

--- a/src/historyStore.ts
+++ b/src/historyStore.ts
@@ -1,0 +1,55 @@
+import type { HistoryEntry, NowPlaying } from "./trackUtils";
+
+const KEY = "rs-history-v1";
+const MAX = 120;
+
+function loadRaw(): HistoryEntry[] {
+  try {
+    const raw = localStorage.getItem(KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(
+      (row): row is HistoryEntry =>
+        row &&
+        typeof row === "object" &&
+        "id" in row &&
+        typeof (row as HistoryEntry).id === "string" &&
+        "playedAt" in row,
+    );
+  } catch {
+    return [];
+  }
+}
+
+function save(entries: HistoryEntry[]) {
+  try {
+    localStorage.setItem(KEY, JSON.stringify(entries));
+  } catch {
+    /* ignore quota */
+  }
+}
+
+export function getHistory(): HistoryEntry[] {
+  return loadRaw();
+}
+
+export function appendHistory(track: NowPlaying): void {
+  if (!track.id) return;
+  const prev = loadRaw();
+  const entry: HistoryEntry = {
+    ...track,
+    playedAt: new Date().toISOString(),
+  };
+  const withoutDup = prev.filter((e) => e.id !== track.id);
+  const next = [entry, ...withoutDup].slice(0, MAX);
+  save(next);
+}
+
+export function clearHistory(): void {
+  try {
+    localStorage.removeItem(KEY);
+  } catch {
+    /* ignore */
+  }
+}

--- a/src/index.css
+++ b/src/index.css
@@ -2,17 +2,106 @@
   box-sizing: border-box;
 }
 
+:root {
+  --bg: #0c0c0e;
+  --bg-elevated: #16161a;
+  --surface: #1c1c21;
+  --border: #2a2a32;
+  --text: #f4f4f5;
+  --text-muted: #a1a1aa;
+  --accent: #1ed760;
+  --accent-hover: #1fdf64;
+  --danger-bg: #3d1a1a;
+  --danger-text: #fecaca;
+  --shadow: 0 24px 48px rgba(0, 0, 0, 0.45);
+  --logo-grad-a: #1ed760;
+  --logo-grad-b: #169c46;
+  --logo-fg: #0a0a0a;
+}
+
+[data-theme="light"] {
+  --bg: #f4f4f5;
+  --bg-elevated: #ffffff;
+  --surface: #ffffff;
+  --border: #e4e4e7;
+  --text: #18181b;
+  --text-muted: #52525b;
+  --accent: #15883e;
+  --accent-hover: #126d33;
+  --danger-bg: #fef2f2;
+  --danger-text: #991b1b;
+  --shadow: 0 20px 40px rgba(0, 0, 0, 0.08);
+  --logo-grad-a: #22c55e;
+  --logo-grad-b: #15803d;
+  --logo-fg: #fafafa;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}
+
+html {
+  color-scheme: dark light;
+}
+
+[data-theme="dark"] {
+  color-scheme: dark;
+}
+
+[data-theme="light"] {
+  color-scheme: light;
+}
+
 body {
   margin: 0;
   min-height: 100vh;
   font-family:
     system-ui,
     -apple-system,
-    Segoe UI,
+    "Segoe UI",
     Roboto,
     Helvetica,
     Arial,
     sans-serif;
-  background: #121212;
-  color: #fafafa;
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+}
+
+a {
+  color: var(--accent);
+}
+
+a:hover {
+  color: var(--accent-hover);
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+kbd {
+  display: inline-block;
+  padding: 0.1em 0.4em;
+  font-size: 0.8em;
+  font-family: inherit;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--bg-elevated);
+  color: var(--text-muted);
 }

--- a/src/spotifyPkce.ts
+++ b/src/spotifyPkce.ts
@@ -15,6 +15,9 @@ const ACCESS_TOKEN_KEY = "spotify_access_token";
 const REFRESH_TOKEN_KEY = "spotify_refresh_token";
 const EXPIRES_AT_KEY = "spotify_expires_at";
 
+/** Open in a new tab so cookies are shared with the OAuth screen (helps mobile users who only use the Spotify app). */
+export const SPOTIFY_ACCOUNTS_LOGIN_URL = "https://accounts.spotify.com/login";
+
 function randomString(length: number): string {
   const possible =
     "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~";
@@ -70,12 +73,87 @@ export function getClientId(): string {
   return fromEnv || DEFAULT_CLIENT_ID;
 }
 
-export async function beginLogin(): Promise<void> {
+/**
+ * Store PKCE verifier + OAuth state in both sessionStorage and localStorage.
+ * Mobile flows (Spotify app, or OAuth opening a new browser tab) often lose sessionStorage;
+ * localStorage keeps the verifier so the callback can still exchange the code.
+ */
+function storeOAuthPkceSession(verifier: string, state: string): void {
+  try {
+    sessionStorage.setItem(PKCE_VERIFIER_KEY, verifier);
+    sessionStorage.setItem(OAUTH_STATE_KEY, state);
+  } catch {
+    /* ignore */
+  }
+  try {
+    localStorage.setItem(PKCE_VERIFIER_KEY, verifier);
+    localStorage.setItem(OAUTH_STATE_KEY, state);
+  } catch {
+    /* ignore */
+  }
+}
+
+function getPkceVerifier(): string | null {
+  try {
+    return (
+      sessionStorage.getItem(PKCE_VERIFIER_KEY) ?? localStorage.getItem(PKCE_VERIFIER_KEY)
+    );
+  } catch {
+    return null;
+  }
+}
+
+function getExpectedOAuthState(): string | null {
+  try {
+    return sessionStorage.getItem(OAUTH_STATE_KEY) ?? localStorage.getItem(OAUTH_STATE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+function clearOAuthPkceSession(): void {
+  try {
+    sessionStorage.removeItem(PKCE_VERIFIER_KEY);
+    sessionStorage.removeItem(OAUTH_STATE_KEY);
+  } catch {
+    /* ignore */
+  }
+  try {
+    localStorage.removeItem(PKCE_VERIFIER_KEY);
+    localStorage.removeItem(OAUTH_STATE_KEY);
+  } catch {
+    /* ignore */
+  }
+}
+
+/** Android Chrome: prefer opening the Spotify app for login (uses in-app session). */
+export function isAndroidMobile(): boolean {
+  if (typeof navigator === "undefined") return false;
+  return /Android/i.test(navigator.userAgent);
+}
+
+export function isIosMobile(): boolean {
+  if (typeof navigator === "undefined") return false;
+  return /iPhone|iPad|iPod/i.test(navigator.userAgent);
+}
+
+/**
+ * Spotify Android: open the native app for authorization when possible.
+ * @see https://stackoverflow.com/questions/77659617/integrating-spotify-oauth-on-android-in-app-authentication-for-web-browsers
+ */
+function androidSpotifyAppIntentUrl(httpsAuthorizeUrl: string): string {
+  const u = new URL(httpsAuthorizeUrl);
+  const query = u.searchParams.toString();
+  const fallback = encodeURIComponent(httpsAuthorizeUrl);
+  return `intent://accounts.spotify.com/inapp-authorize?${query};scheme=https;package=com.spotify.music;S.browser_fallback_url=${fallback};end`;
+}
+
+async function buildAuthorizeUrl(): Promise<string> {
   const clientId = getClientId();
   const { verifier, challenge } = await generatePkcePair();
   const state = randomString(16);
-  sessionStorage.setItem(PKCE_VERIFIER_KEY, verifier);
-  sessionStorage.setItem(OAUTH_STATE_KEY, state);
+  clearOAuthPkceSession();
+  storeOAuthPkceSession(verifier, state);
 
   const params = new URLSearchParams({
     client_id: clientId,
@@ -88,7 +166,18 @@ export async function beginLogin(): Promise<void> {
     show_dialog: "false",
   });
 
-  window.location.assign(`${SPOTIFY_AUTH}?${params.toString()}`);
+  return `${SPOTIFY_AUTH}?${params.toString()}`;
+}
+
+export async function beginLogin(): Promise<void> {
+  const httpsUrl = await buildAuthorizeUrl();
+
+  if (isAndroidMobile()) {
+    window.location.assign(androidSpotifyAppIntentUrl(httpsUrl));
+    return;
+  }
+
+  window.location.assign(httpsUrl);
 }
 
 type TokenResponse = {
@@ -99,7 +188,7 @@ type TokenResponse = {
 };
 
 export async function exchangeCodeForTokens(code: string): Promise<void> {
-  const verifier = sessionStorage.getItem(PKCE_VERIFIER_KEY);
+  const verifier = getPkceVerifier();
   if (!verifier) {
     throw new Error("PKCE verifier missing — try logging in again.");
   }
@@ -125,8 +214,7 @@ export async function exchangeCodeForTokens(code: string): Promise<void> {
 
   const data = (await res.json()) as TokenResponse;
   persistTokens(data);
-  sessionStorage.removeItem(PKCE_VERIFIER_KEY);
-  sessionStorage.removeItem(OAUTH_STATE_KEY);
+  clearOAuthPkceSession();
 }
 
 export async function refreshAccessToken(): Promise<boolean> {
@@ -194,6 +282,6 @@ export function parseOAuthCallback(): { code: string; state: string } | null {
 }
 
 export function validateOAuthState(returnedState: string): boolean {
-  const expected = sessionStorage.getItem(OAUTH_STATE_KEY);
+  const expected = getExpectedOAuthState();
   return expected !== null && expected === returnedState;
 }

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,0 +1,28 @@
+const STORAGE_KEY = "rs-theme";
+
+export type ThemeMode = "light" | "dark";
+
+export function getStoredTheme(): ThemeMode | null {
+  try {
+    const v = localStorage.getItem(STORAGE_KEY);
+    if (v === "light" || v === "dark") return v;
+  } catch {
+    /* ignore */
+  }
+  return null;
+}
+
+export function applyTheme(theme: ThemeMode): void {
+  document.documentElement.setAttribute("data-theme", theme);
+  try {
+    localStorage.setItem(STORAGE_KEY, theme);
+  } catch {
+    /* ignore */
+  }
+}
+
+export function toggleTheme(current: ThemeMode): ThemeMode {
+  const next: ThemeMode = current === "dark" ? "light" : "dark";
+  applyTheme(next);
+  return next;
+}

--- a/src/trackUtils.ts
+++ b/src/trackUtils.ts
@@ -1,0 +1,55 @@
+export const DEFAULT_IMG =
+  "https://images.squarespace-cdn.com/content/v1/585e12abe4fcb5ea1248900e/1521163355433-O0YP7FRVMXHTCHB1O4CU/ke17ZwdGBToddI8pDm48kPx25wW2-RVvoRgxIT6HShBZw-zPPgdn4jUwVcJE1ZvWQUxwkmyExglNqGp0IvTJZUJFbgE-7XRK3dMEBRBhUpx0Qh3eD5PfZ_nDR0M7OIGaTx-0Okj4hzQeRKYKbt7WfTYFScRKDTW78PcnUqBGqX8/Spotify+Square.png";
+
+export type NowPlaying = {
+  id: string;
+  name: string;
+  artist: string;
+  album: string;
+  image: string;
+  uri: string;
+  externalUrl: string;
+};
+
+export type HistoryEntry = NowPlaying & { playedAt: string };
+
+export function emptyNowPlaying(): NowPlaying {
+  return {
+    id: "",
+    name: "",
+    artist: "",
+    album: "",
+    image: DEFAULT_IMG,
+    uri: "",
+    externalUrl: "",
+  };
+}
+
+type TrackLike = {
+  id: string;
+  name: string;
+  artists: { name: string }[];
+  album?: { name: string; images: { url: string }[] };
+  uri: string;
+  external_urls?: { spotify?: string };
+};
+
+export function trackToNowPlaying(t: TrackLike): NowPlaying {
+  return {
+    id: t.id,
+    name: t.name,
+    artist: t.artists[0]?.name ?? "",
+    album: t.album?.name ?? "",
+    image: t.album?.images[0]?.url ?? DEFAULT_IMG,
+    uri: t.uri,
+    externalUrl: t.external_urls?.spotify ?? `https://open.spotify.com/track/${t.id}`,
+  };
+}
+
+export function appBaseUrl(): string {
+  if (typeof window === "undefined") {
+    return "https://saarhaber.github.io/randomSong/";
+  }
+  const base = import.meta.env.BASE_URL;
+  return new URL(base, window.location.origin).href;
+}


### PR DESCRIPTION
## Summary
- Playback history sidebar, dark/light theme, share with `?track=` deep links, logo/favicon/manifest
- Spotify search: cap `offset` so `limit + offset ≤ 1000`
- Auth: PKCE stored for mobile handoffs; Android intent to open Spotify app when available

Base: `master`

Made with [Cursor](https://cursor.com)