### PR TITLE
Android Spotify connect, OAuth flow, branding

### DIFF
--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -6,5 +6,10 @@
     </linearGradient>
   </defs>
   <rect x="1" y="1" width="30" height="30" rx="8" fill="url(#g)" />
-  <text x="16" y="22" text-anchor="middle" font-size="15" fill="#0d0d0d" font-family="system-ui,sans-serif" font-weight="700">j</text>
+  <!-- Material-style note; vector only (no text) for crisp favicons -->
+  <path
+    fill="#0d0d0d"
+    transform="translate(5,5) scale(0.92)"
+    d="M12 3v10.55c-.59-.34-1.27-.55-2-.55-2.21 0-4 1.79-4 4s1.79 4 4 4 4-1.79 4-4V7h4V3h-6z"
+  />
 </svg>

--- a/src/App.css
+++ b/src/App.css
@@ -195,6 +195,10 @@
   margin-right: auto;
 }
 
+.login-app-try {
+  margin-top: 0.75rem;
+}
+
 .login-warmup {
   margin: 1.25rem 0 0;
   padding: 0.85rem 1rem;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,8 @@ import {
   ensureValidAccessToken,
   exchangeCodeForTokens,
   getClientId,
+  androidUsesSpotifyAppIntentForLogin,
+  beginLoginTrySpotifyAppIntent,
   isAndroidMobile,
   isIosMobile,
   parseOAuthCallback,
@@ -496,6 +498,13 @@ export default function App() {
     });
   };
 
+  const onLoginTrySpotifyApp = () => {
+    setError(null);
+    void beginLoginTrySpotifyAppIntent().catch((e) => {
+      setError(formatSpotifyApiError(e));
+    });
+  };
+
   const onLogout = () => {
     clearStoredTokens();
     setLoggedIn(false);
@@ -615,10 +624,32 @@ export default function App() {
                 Connect Spotify
               </button>
               {isAndroidMobile() ? (
-                <p className="hint hint--tight">
-                  On Android, this opens the <strong>Spotify app</strong> if it’s installed (you stay
-                  logged in there). Otherwise your browser completes sign-in.
-                </p>
+                androidUsesSpotifyAppIntentForLogin() ? (
+                  <p className="hint hint--tight">
+                    On Android, this opens the <strong>Spotify app</strong> if it’s installed (you stay
+                    logged in there). Otherwise your browser completes sign-in.
+                  </p>
+                ) : (
+                  <>
+                    <p className="hint hint--tight">
+                      On Android with this browser, Spotify sign-in opens <strong>in the browser</strong>.
+                      Use the same account you use in the Spotify app.
+                    </p>
+                    <button
+                      type="button"
+                      className="btn btn-secondary btn-sm login-app-try"
+                      onClick={onLoginTrySpotifyApp}
+                    >
+                      Try opening in Spotify app
+                    </button>
+                    <p className="hint hint--tight">
+                      Sites can’t force Android to open another app—only the browser and OS can. This
+                      uses the same app link as Chrome; if nothing happens, allow app links for Spotify
+                      in Brave’s settings or complete connect in{" "}
+                      <strong>Chrome</strong> for a reliable handoff.
+                    </p>
+                  </>
+                )
               ) : isIosMobile() ? (
                 <p className="hint hint--tight">
                   On iPhone, sign-in happens in Safari. If you only use Spotify in the app, use the{" "}

--- a/src/components/Logo.tsx
+++ b/src/components/Logo.tsx
@@ -16,17 +16,11 @@ export function Logo({ className }: LogoProps) {
         </linearGradient>
       </defs>
       <rect x="1" y="1" width="30" height="30" rx="8" fill="url(#logoGrad)" />
-      <text
-        x="16"
-        y="22"
-        textAnchor="middle"
-        fontSize="15"
+      <path
         fill="var(--logo-fg, #0d0d0d)"
-        fontFamily="system-ui, sans-serif"
-        fontWeight="700"
-      >
-        ♪
-      </text>
+        transform="translate(5,5) scale(0.92)"
+        d="M12 3v10.55c-.59-.34-1.27-.55-2-.55-2.21 0-4 1.79-4 4s1.79 4 4 4 4-1.79 4-4V7h4V3h-6z"
+      />
     </svg>
   );
 }

--- a/src/spotifyPkce.ts
+++ b/src/spotifyPkce.ts
@@ -132,6 +132,19 @@ export function isAndroidMobile(): boolean {
   return /Android/i.test(navigator.userAgent);
 }
 
+/**
+ * Google Chrome for Android resolves Spotify’s `intent://` OAuth URL to the native app.
+ * Browsers such as Brave, Edge, and Samsung Internet often ignore it or fail to fall back,
+ * so those users should use the normal HTTPS authorize URL in the same tab.
+ */
+export function androidUsesSpotifyAppIntentForLogin(): boolean {
+  if (typeof navigator === "undefined") return false;
+  const ua = navigator.userAgent;
+  if (!/Android/i.test(ua) || !/Chrome/i.test(ua)) return false;
+  if (/Edg|Brave|OPR|SamsungBrowser|Firefox|Vivaldi|YaBrowser/i.test(ua)) return false;
+  return true;
+}
+
 export function isIosMobile(): boolean {
   if (typeof navigator === "undefined") return false;
   return /iPhone|iPad|iPod/i.test(navigator.userAgent);
@@ -172,11 +185,26 @@ async function buildAuthorizeUrl(): Promise<string> {
 export async function beginLogin(): Promise<void> {
   const httpsUrl = await buildAuthorizeUrl();
 
-  if (isAndroidMobile()) {
+  if (androidUsesSpotifyAppIntentForLogin()) {
     window.location.assign(androidSpotifyAppIntentUrl(httpsUrl));
     return;
   }
 
+  window.location.assign(httpsUrl);
+}
+
+/**
+ * Android: always uses Spotify’s `intent://` handoff to the native app (same OAuth request
+ * as {@link beginLogin}, but a fresh PKCE session). Browsers may still ignore or block
+ * `intent://`; there is no web API to force an app open. Use when the user explicitly
+ * wants to try the app path (e.g. Brave default flow uses the browser instead).
+ */
+export async function beginLoginTrySpotifyAppIntent(): Promise<void> {
+  const httpsUrl = await buildAuthorizeUrl();
+  if (isAndroidMobile()) {
+    window.location.assign(androidSpotifyAppIntentUrl(httpsUrl));
+    return;
+  }
   window.location.assign(httpsUrl);
 }
 


### PR DESCRIPTION
This PR updates Spotify login for Android (Brave and similar browsers): HTTPS OAuth by default where `intent://` is unreliable, optional "Try opening in Spotify app" for users who want the native handoff, and refreshed logo/favicon assets.

Made with [Cursor](https://cursor.com)