### PR TITLE
Random search helpers and retry empty Spotify results

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -357,18 +357,25 @@ export default function App() {
         return;
       }
 
-      const market = MARKETS[Math.floor(Math.random() * MARKETS.length)]!;
-      const search = getRandomSearch();
       /** Spotify search: limit + offset must not exceed 1000. */
       const searchLimit = 50;
       const maxOffset = 1000 - searchLimit;
-      const offset = Math.floor(Math.random() * (maxOffset + 1));
-      const response = await spotify.search(search, ["track"], {
-        market,
-        limit: searchLimit,
-        offset,
-      });
-      const items = response.tracks?.items ?? [];
+      const maxSearchAttempts = 10;
+      let items: NonNullable<
+        Awaited<ReturnType<typeof spotify.search>>["tracks"]
+      >["items"] = [];
+      for (let attempt = 0; attempt < maxSearchAttempts; attempt++) {
+        const market = MARKETS[Math.floor(Math.random() * MARKETS.length)]!;
+        const search = getRandomSearch();
+        const offset = Math.floor(Math.random() * (maxOffset + 1));
+        const response = await spotify.search(search, ["track"], {
+          market,
+          limit: searchLimit,
+          offset,
+        });
+        items = response.tracks?.items ?? [];
+        if (items.length > 0) break;
+      }
       if (items.length === 0) {
         setError("No tracks returned — try again.");
         return;

--- a/src/random.ts
+++ b/src/random.ts
@@ -1,0 +1,28 @@
+/**
+ * Uniform integer in [0, upperExclusive). Uses crypto.getRandomValues with
+ * rejection sampling when available; otherwise Math.random.
+ */
+export function randomInt(upperExclusive: number): number {
+  if (!Number.isFinite(upperExclusive) || upperExclusive <= 0) {
+    throw new RangeError("randomInt: upperExclusive must be a positive finite number");
+  }
+  const upper = Math.floor(upperExclusive);
+  if (upper <= 0) {
+    throw new RangeError("randomInt: upperExclusive must be at least 1");
+  }
+
+  const cryptoObj = globalThis.crypto;
+  if (cryptoObj?.getRandomValues) {
+    const modulus = 0x1_0000_0000;
+    const limit = Math.floor(modulus / upper) * upper;
+    const buf = new Uint32Array(1);
+    let x: number;
+    do {
+      cryptoObj.getRandomValues(buf);
+      x = buf[0]!;
+    } while (x >= limit);
+    return x % upper;
+  }
+
+  return Math.floor(Math.random() * upper);
+}

--- a/src/randomSearchQuery.ts
+++ b/src/randomSearchQuery.ts
@@ -1,0 +1,120 @@
+import { randomInt } from "./random";
+
+const CHARACTERS =
+  "ﺍﺏﺕﺙﺝﺡﺥﺩﺫﺭﺯﺱﺵﺹﺽﻁﻅﻉﻍﻑﻕﻙﻝﻡﻥهـﻭﻱБВГДЖꙂꙀИЛѠЦЧШЩЪѢꙖѤЮѪѬѦѨѮѰѲѴҀňřšťůýÿžäëðöüăïîāņßķõőàèòùčēļșģìאבגדהוזחטיכלמנסעפצקרשתľơŕçởżğæœøåabcdefghijklmnñopqrstuvwxyz0123456789áéíóúαβγδεζηθικλμνξΟοΠπρςτυφχψωč";
+
+/** Short seeds for varied catalog slices (Spotify matches track/album/artist text). */
+const SEED_WORDS = [
+  "jazz",
+  "punk",
+  "ambient",
+  "folk",
+  "blues",
+  "salsa",
+  "disco",
+  "techno",
+  "lofi",
+  "indie",
+  "metal",
+  "reggae",
+  "samba",
+  "waltz",
+  "mambo",
+  "swing",
+  "gospel",
+  "cello",
+  "violin",
+  "drums",
+  "bass",
+  "piano",
+  "acoustic",
+  "remix",
+  "live",
+  "slow",
+  "fast",
+  "night",
+  "summer",
+  "winter",
+  "love",
+  "storm",
+  "dream",
+  "city",
+  "road",
+  "ocean",
+  "fire",
+  "gold",
+  "silver",
+  "neon",
+  "vintage",
+] as const;
+
+function randomChar(): string {
+  return CHARACTERS.charAt(randomInt(CHARACTERS.length))!;
+}
+
+function wildcardPattern(oneOrTwo: string): string {
+  const mode = randomInt(3);
+  if (mode === 0) {
+    return oneOrTwo + "%";
+  }
+  if (mode === 1) {
+    return "%" + oneOrTwo + "%";
+  }
+  return oneOrTwo;
+}
+
+function randomWildcardQuery(): string {
+  if (randomInt(2) === 0) {
+    return wildcardPattern(randomChar());
+  }
+  return wildcardPattern(randomChar() + randomChar());
+}
+
+function randomSeedWordQuery(): string {
+  const word = SEED_WORDS[randomInt(SEED_WORDS.length)]!;
+  const variant = randomInt(4);
+  if (variant === 0) {
+    return word + "%";
+  }
+  if (variant === 1) {
+    return "%" + word + "%";
+  }
+  if (variant === 2) {
+    return word + " " + randomChar() + "%";
+  }
+  return word;
+}
+
+/** Decade and shorter ranges for `year:` filter (Spotify search). */
+function randomYearQuery(): string {
+  const startDecade = 1950 + randomInt(8) * 10;
+  const endDecade = startDecade + 9;
+  const yearFilter = `year:${startDecade}-${endDecade}`;
+  const mix = randomInt(4);
+  if (mix === 0) {
+    return `${yearFilter} ${randomChar()}%`;
+  }
+  if (mix === 1) {
+    return `${yearFilter} ${SEED_WORDS[randomInt(SEED_WORDS.length)]!}`;
+  }
+  if (mix === 2) {
+    return `${yearFilter} %${randomChar()}%`;
+  }
+  return yearFilter;
+}
+
+const STRATEGY_COUNT = 3;
+
+/**
+ * Random search query string for Spotify track search (diverse strategies).
+ */
+export function randomSearchQuery(): string {
+  const strategy = randomInt(STRATEGY_COUNT);
+  if (strategy === 0) {
+    return randomWildcardQuery();
+  }
+  if (strategy === 1) {
+    return randomSeedWordQuery();
+  }
+  return randomYearQuery();
+}


### PR DESCRIPTION
Staged changes only: `randomInt` + `randomSearchQuery` modules, App wiring, and retries when search returns no tracks (avoids empty results after track end / auto-advance).

Made with [Cursor](https://cursor.com)